### PR TITLE
fix import error and fix syntax error in strftime function

### DIFF
--- a/gofile2/gofile2.py
+++ b/gofile2/gofile2.py
@@ -3,7 +3,7 @@
 # Project: Gofile2
 import os
 
-from time import time, strftime
+import time
 from requests import delete, get, post, put
 from .errors import (InvalidOption, InvalidPath, InvalidToken, JobFailed,
                      ResponseError, is_valid_token)
@@ -104,7 +104,7 @@ class Gofile:
         # Get folder id if not passed
         if not folderId:
             rtfid = self.get_Account()["rootFolder"]
-            folderId = self.create_folder(rtfid, "Gofile2 - Created in {}".format(strftime("%b %d, %Y %l:%M%p")))["id"]
+            folderId = self.create_folder(rtfid, "Gofile2 - Created in {}".format(time.strftime("%b %d, %Y %I:%M%p")))["id"]
         for file in files:
             udt = self.upload(file, folderId)
             uploaded.append(udt)


### PR DESCRIPTION
There is a problem with the new version. You successfully solve the folder uploading problem but somehow made a syntax mistake. v1.4.3 code cannot be compiled at the moment. I fix the problem. Briefly:
- You want to use time.sleep(x) but you import time wrongly
- You mistakenly write %l instead of %I in strftime function. ( /L/ouisiana instead of /I/ndiana )

Thank you for the nice lib.